### PR TITLE
Fix/default model

### DIFF
--- a/src/app/store/filterSlice.ts
+++ b/src/app/store/filterSlice.ts
@@ -25,7 +25,7 @@ interface FilterState {
 const initialState: FilterState = {
     selectedStateName: "United States",
     USStateNum: "US",
-    forecastModel: ["MOBS-GLEAM_FLUH"],
+    forecastModel: ['MOBS-GLEAM_FLUH', 'CEPH-Rtrend_fluH', 'MIGHTE-Nsemble', 'NU_UCSD-GLEAM_AI_FLUH', 'FluSight-ensemble'],
     numOfWeeksAhead: 3,
     dateRange: "2023-08-01/2024-05-18",
     dateStart: parseISO("2023-08-01T12:00:00Z"),


### PR DESCRIPTION
Weekly hostpitalization chart now finds the most recent date with prediction for United States and use that date by default; also all the models are toggled on by default