### PR TITLE
Pipeline/deployment fix schedule update

### DIFF
--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -120,3 +120,14 @@ jobs:
           fi
           
           echo "Successfully updated main and production branches with tag: ${TAG_NAME}"
+          
+          # Set an output to indicate successful push
+          echo "PRODUCTION_UPDATED=true" >> $GITHUB_ENV
+
+      - name: Trigger deployment workflow by sending a workflow_dispatch event
+#        TODO: Uncomment the following line when test is done
+#        if: ${{ env.PRODUCTION_UPDATED == 'true' }}
+        run: |
+          gh workflow run "Deploy to GCP App Engine Default Service"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} #NOTE: this is not necessary but just in case

--- a/.github/workflows/data-pipeline.yaml
+++ b/.github/workflows/data-pipeline.yaml
@@ -3,6 +3,7 @@ name: Weekly Data Update
 on:
   schedule:
     - cron: '30 6-21/3 * * 4'  # Runs every Thursday, starting from 6:30 AM UTC until 9:30 PM UTC, every 3 hours
+    - cron: '30 21 * * 5,6'   # Separately runs another two times, on every Friday and Saturday at 9:30 PM UTC
   workflow_dispatch:
 
 concurrency:
@@ -124,9 +125,10 @@ jobs:
           # Set an output to indicate successful push
           echo "PRODUCTION_UPDATED=true" >> $GITHUB_ENV
 
-      - name: Trigger deployment workflow by sending a workflow_dispatch event
-#        TODO: Uncomment the following line when test is done
-#        if: ${{ env.PRODUCTION_UPDATED == 'true' }}
+        # GitHub bans workflow calling workflows
+        # So we deliberately call a workflow_dispatch event to trigger deployment-to-gcp.yaml workflow
+      - name: Trigger Deployment Workflow
+        if: ${{ env.PRODUCTION_UPDATED == 'true' }}
         run: |
           gh workflow run "Deploy to GCP App Engine Default Service"
         env:

--- a/.github/workflows/deploy-to-gcp.yaml
+++ b/.github/workflows/deploy-to-gcp.yaml
@@ -3,8 +3,10 @@ name: Deploy to GCP App Engine Default Service
 on:
   push:
     branches:
-      - production
+      - 'production'
   workflow_dispatch:
+  workflow_call:
+
 
 jobs:
   deploy:


### PR DESCRIPTION
- Fixed issue where deployment to Google Cloud App Engine cannot be triggered by the data pipeline's push to `production` branch
- Added two separate runs at 21:30 UTC on every Friday and Saturday to account for late data submissions