### PR TITLE
fixed historical surveillance data display issue

### DIFF
--- a/src/app/forecasts/forecasts-components/ForecastChart.tsx
+++ b/src/app/forecasts/forecasts-components/ForecastChart.tsx
@@ -72,7 +72,7 @@ const ForecastChart: React.FC = () => {
         const baseMarginTop = Math.max(20 + (zoomFactor * 12), height * 0.1);
         const baseMarginBottom = Math.max(20 + (zoomFactor * 25), height * 0.15);
         const baseMarginLeft = Math.max(20 + (zoomFactor * 25), width * 0.038);
-        // console.log("DEBUG: Base Margin Left:", baseMarginLeft);
+        // console.debug("DEBUG: Base Margin Left:", baseMarginLeft);
         const baseMarginRight = Math.max(20 - (zoomFactor * 12), width * 0.02);
 
 
@@ -98,7 +98,7 @@ const ForecastChart: React.FC = () => {
         // Filter data by extracting those entries that fall within the selected date range
         filteredGroundTruthDataByState = filteredGroundTruthDataByState.filter((d) => d.date >= groundTruthDateRange[0] && d.date <= groundTruthDateRange[1],);
 
-        console.log("DEBUG: ForecastChart: Filtered Ground Truth Data:", filteredGroundTruthDataByState);
+        console.debug("DEBUG: ForecastChart: Filtered Ground Truth Data:", filteredGroundTruthDataByState);
 
         return filteredGroundTruthDataByState;
     }
@@ -202,7 +202,7 @@ const ForecastChart: React.FC = () => {
             }, new Date(0));
 
         const maxDate = d3.max([maxGroundTruthDate, maxPredictionDate]) as Date;
-        console.log("DEBUG: ForecastChart: createScalesAndAxes(): maxDate: ", maxDate);
+        console.debug("DEBUG: ForecastChart: createScalesAndAxes(): maxDate: ", maxDate);
 
         const xScale = d3
             .scaleUtc()
@@ -214,7 +214,7 @@ const ForecastChart: React.FC = () => {
             .range(dateStart, maxDate)
             .filter((d) => d.getDay() === 6);
 
-        // console.log("DEBUG: ForecastChart: createScalesAndAxes(): allSaturdayTracker: ", allSaturdayTracker);
+        // console.debug("DEBUG: ForecastChart: createScalesAndAxes(): allSaturdayTracker: ", allSaturdayTracker);
 
         // Determine the ideal number of ticks
         const idealTickCount = Math.min(Math.max(10, allSaturdayTracker.length), 20);
@@ -252,7 +252,7 @@ const ForecastChart: React.FC = () => {
         const maxGroundTruthValue = d3.max(ground.filter((d) => d.admissions !== -1), (d) => d.admissions) as number;
 
         let maxPredictionValue = 0;
-        // console.log("DEBUG: ForecastChart: createScalesAndAxes(): predictions: ", predictions);
+        // console.debug("DEBUG: ForecastChart: createScalesAndAxes(): predictions: ", predictions);
 
         if (predictions && Object.keys(predictions).length > 0) {
             maxPredictionValue = Object.values(predictions).reduce((max, modelData: PredictionDataPoint[]) => {
@@ -275,10 +275,10 @@ const ForecastChart: React.FC = () => {
             }, 0);
         }
 
-        // console.log("DEBUG: ForecastChart: createScalesAndAxes(): maxPredictionValue: ", maxPredictionValue);
+        // console.debug("DEBUG: ForecastChart: createScalesAndAxes(): maxPredictionValue: ", maxPredictionValue);
 
         let maxValue = Math.max(maxGroundTruthValue, maxPredictionValue);
-        // console.log("DEBUG: ForecastChart: createScalesAndAxes(): maxValue: ", maxValue);
+        // console.debug("DEBUG: ForecastChart: createScalesAndAxes(): maxValue: ", maxValue);
 
         let minValue = d3.min(ground.filter((d) => d.admissions !== -1), (d) => d.admissions) as number;
 
@@ -301,8 +301,8 @@ const ForecastChart: React.FC = () => {
                 .range([chartHeight, 0]);
         }
 
-        console.log("DEBUG: ForecastChart: createScalesAndAxes(): minValue: ", minValue);
-        console.log("DEBUG: ForecastChart: createScalesAndAxes(): maxValue: ", maxValue);
+        console.debug("DEBUG: ForecastChart: createScalesAndAxes(): minValue: ", minValue);
+        console.debug("DEBUG: ForecastChart: createScalesAndAxes(): maxValue: ", maxValue);
         const ticks = generateYAxisTicks(minValue, maxValue, isLogScale);
 
         const yAxis = d3.axisLeft(yScale)
@@ -433,25 +433,23 @@ const ForecastChart: React.FC = () => {
 
     function renderHistoricalData(svg: d3.Selection<SVGSVGElement, unknown, null, undefined>, historicalData: HistoricalDataEntry[], xScale: d3.ScaleTime<number, number>, yScale: d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>, marginLeft: number, marginTop: number) {
 
-        console.log("DEBUG: ForecastChart: Rendering historical data:", historicalData);
-        console.log("DEBUG: ForecastChart: User selected week:", userSelectedWeek);
+        console.debug("DEBUG: ForecastChart: renderHistoricalData(): incoming historical data (parameter):", historicalData);
+
+        console.debug("DEBUG: ForecastChart: User selected week:", userSelectedWeek);
 
         // Find the historical data file that is 1 week before the user selected week,
         // While accounting for day light saving time transitions, using a 2-hour buffer, using isUTCDateEqual
         const matchingHistoricalData = historicalData.find((entry) => isUTCDateEqual(entry.associatedDate, subWeeks(userSelectedWeek, 1)));
 
-
-        // const matchingHistoricalData = historicalData.find((entry) => isUTCDateEqual(entry.associatedDate, userSelectedWeek));
-
         if (!matchingHistoricalData) {
-            console.log("DEBUG: No matching historical data found for:", userSelectedWeek.toISOString());
+            console.debug("DEBUG: No matching historical data found for:", userSelectedWeek.toISOString());
             return;
         }
 
-        console.log("DEBUG: Matching historical data:", matchingHistoricalData);
+        console.debug("DEBUG: ForecastChart.tsx: renderHistoricalData(): Final matching historical data:", matchingHistoricalData);
 
         /*Ensure the historical data to be drawn is cutoff before dateStart*/
-        const historicalDataToDraw = matchingHistoricalData.historicalData.filter((d) => d.date >= dateStart);
+        const historicalDataToDraw = matchingHistoricalData.historicalData.filter((d) => d.date >= dateStart).filter(d => d.admissions !== -1 && d.stateNum === USStateNum).sort((a, b) => a.date.getTime() - b.date.getTime());
 
         const historicalLine = d3
             .line<DataPoint>()
@@ -461,7 +459,7 @@ const ForecastChart: React.FC = () => {
 
         svg
             .append("path")
-            .datum(historicalDataToDraw.filter(d => d.admissions !== -1 && !isNaN(d.admissions) && d.stateNum === USStateNum))
+            .datum(historicalDataToDraw)
             .attr("class", "historical-ground-truth-path")
             .attr("fill", "none")
             .attr("stroke", "#FFA500") // Orange color for historical data
@@ -471,7 +469,7 @@ const ForecastChart: React.FC = () => {
 
         svg
             .selectAll(".historical-ground-truth-dot")
-            .data(historicalDataToDraw.filter(d => d.admissions !== -1 && !isNaN(d.admissions) && d.stateNum === USStateNum))
+            .data(historicalDataToDraw)
             .enter()
             .append("circle")
             .attr("class", "historical-ground-truth-dot")
@@ -638,7 +636,7 @@ const ForecastChart: React.FC = () => {
 
     function createCornerTooltip(svg: d3.Selection<SVGSVGElement, unknown, null, undefined>, marginLeft: number, marginTop: number, chartWidth: number,) {
 
-        // console.log('DEBUG: Initial tooltip position:', marginLeft + 20, marginTop + 20);
+        // console.debug('DEBUG: Initial tooltip position:', marginLeft + 20, marginTop + 20);
         return svg
             .append("g")
             .attr("class", "corner-tooltip")
@@ -758,10 +756,10 @@ const ForecastChart: React.FC = () => {
         const tooltipX = shouldShowOnRightSide ? chartWidth - maxWidth - padding * 2 : 60;
         const tooltipY = marginTop;
 
-        /*console.log('Updating tooltip position:', tooltipX, tooltipY);
-        console.log('Chart width:', chartWidth);
-        console.log('Corner Tooltip on upper-right:', shouldShowOnRightSide);
-        console.log('Max width:', maxWidth);*/
+        /*console.debug('Updating tooltip position:', tooltipX, tooltipY);
+        console.debug('Chart width:', chartWidth);
+        console.debug('Corner Tooltip on upper-right:', shouldShowOnRightSide);
+        console.debug('Max width:', maxWidth);*/
 
         cornerTooltip
             .attr('transform', `translate(${tooltipX}, ${tooltipY})`)
@@ -1009,7 +1007,7 @@ const ForecastChart: React.FC = () => {
     }
 
     function bubbleUserSelectedWeek(date: Date) {
-        console.log("Bubbling user selected week:", date.toISOString());
+        console.debug("Bubbling user selected week:", date.toISOString());
         dispatch(updateUserSelectedWeek(new Date(date.toISOString()))); // Ensure UTC
     }
 


### PR DESCRIPTION
Fixed issue where historical data's render path skips entire time span when 2025's new data has the historical data stored out-of-order