### PR TITLE
Feat/exp/forecast/forecast chart/new margin

### DIFF
--- a/src/app/Interfaces/chart-margin-utils.ts
+++ b/src/app/Interfaces/chart-margin-utils.ts
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+
+interface MarginConfig {
+  minTopMargin: number;
+  minBottomMargin: number;
+  minLeftMargin: number;
+  minRightMargin: number;
+  topMarginRatio: number;
+  bottomMarginRatio: number;
+  leftMarginRatio: number;
+  rightMarginRatio: number;
+}
+
+// Default configurations for different chart types
+const defaultMarginConfigs: Record<string, MarginConfig> = {
+  default: {
+    minTopMargin: 40,
+    minBottomMargin: 60,
+    minLeftMargin: 60,
+    minRightMargin: 30,
+    topMarginRatio: 0.08,
+    bottomMarginRatio: 0.12,
+    leftMarginRatio: 0.1,
+    rightMarginRatio: 0.05
+  },
+  dense: {
+    minTopMargin: 30,
+    minBottomMargin: 50,
+    minLeftMargin: 50,
+    minRightMargin: 25,
+    topMarginRatio: 0.06,
+    bottomMarginRatio: 0.1,
+    leftMarginRatio: 0.08,
+    rightMarginRatio: 0.04
+  }
+};
+
+export function useChartMargins(
+  containerWidth: number,
+  containerHeight: number,
+  configType: keyof typeof defaultMarginConfigs = 'default'
+) {
+  const [zoomLevel, setZoomLevel] = useState(1);
+  const [margins, setMargins] = useState({ top: 0, right: 0, bottom: 0, left: 0 });
+
+  // Detect zoom level changes
+  useEffect(() => {
+    const detectZoom = () => {
+      const zoom = window.devicePixelRatio || 1;
+      setZoomLevel(zoom);
+    };
+
+    detectZoom();
+    window.addEventListener('resize', detectZoom);
+    return () => window.removeEventListener('resize', detectZoom);
+  }, []);
+
+  // Update margins based on container size and zoom
+  useEffect(() => {
+    const config = defaultMarginConfigs[configType];
+    const zoomFactor = Math.max(0.8, Math.min(1.2, zoomLevel)); // Limit zoom impact
+
+    // Calculate responsive margins with minimum bounds
+    const calculateMargin = (
+      minMargin: number,
+      ratio: number,
+      dimension: number
+    ) => {
+      const responsiveMargin = Math.max(
+        minMargin,
+        dimension * ratio * zoomFactor
+      );
+      // Ensure margin doesn't exceed 25% of the dimension
+      return Math.min(responsiveMargin, dimension * 0.25);
+    };
+
+    const newMargins = {
+      top: calculateMargin(config.minTopMargin, config.topMarginRatio, containerHeight),
+      right: calculateMargin(config.minRightMargin, config.rightMarginRatio, containerWidth),
+      bottom: calculateMargin(config.minBottomMargin, config.bottomMarginRatio, containerHeight),
+      left: calculateMargin(config.minLeftMargin, config.leftMarginRatio, containerWidth)
+    };
+
+    setMargins(newMargins);
+  }, [containerWidth, containerHeight, zoomLevel, configType]);
+
+  return margins;
+}
+
+// Utility for calculating label sizes
+export function calculateLabelSpace(
+  svg: d3.Selection<SVGGElement, unknown, null, undefined>,
+  labels: string[],
+  fontSize: number
+): { width: number; height: number } {
+  const temp = svg
+    .append('text')
+    .style('font-size', `${fontSize}px`)
+    .style('opacity', 0);
+
+  const maxWidth = Math.max(
+    ...labels.map(label => {
+      temp.text(label);
+      return temp.node()?.getComputedTextLength() || 0;
+    })
+  );
+
+  temp.remove();
+
+  return {
+    width: maxWidth,
+    height: fontSize * 1.2 // Approximate line height
+  };
+}

--- a/src/app/Interfaces/chart-margin-utils.ts
+++ b/src/app/Interfaces/chart-margin-utils.ts
@@ -16,12 +16,12 @@ const defaultMarginConfigs: Record<string, MarginConfig> = {
   default: {
     minTopMargin: 40,
     minBottomMargin: 60,
-    minLeftMargin: 60,
-    minRightMargin: 30,
+    minLeftMargin: 40,
+    minRightMargin: 40,
     topMarginRatio: 0.08,
     bottomMarginRatio: 0.12,
-    leftMarginRatio: 0.1,
-    rightMarginRatio: 0.05
+    leftMarginRatio: 0.04,
+    rightMarginRatio: 0.04
   },
   dense: {
     minTopMargin: 30,
@@ -70,8 +70,8 @@ export function useChartMargins(
         minMargin,
         dimension * ratio * zoomFactor
       );
-      // Ensure margin doesn't exceed 25% of the dimension
-      return Math.min(responsiveMargin, dimension * 0.25);
+      // Ensure margin doesn't exceed 22% of the dimension
+      return Math.min(responsiveMargin, dimension * 0.22);
     };
 
     const newMargins = {

--- a/src/app/Interfaces/forecast-chart-dimension-observer.ts
+++ b/src/app/Interfaces/forecast-chart-dimension-observer.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import debounce from "lodash/debounce";
+
+interface ChartDimensions {
+  width: number;
+  height: number;
+  zoomLevel: number;
+}
+
+export function useChartDimensions(
+  debounceMs: number = 100
+): [React.RefObject<HTMLDivElement>, ChartDimensions] {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState<ChartDimensions>({
+    width: 0,
+    height: 0,
+    zoomLevel: 1,
+  });
+
+  // Debounced dimension update
+  const debouncedSetDimensions = useCallback(
+    debounce((width: number, height: number, zoom: number) => {
+      setDimensions({ width, height, zoomLevel: zoom });
+    }, debounceMs),
+    []
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const updateDimensions = () => {
+      const zoom = window.devicePixelRatio || 1;
+      if (containerRef.current) {
+        debouncedSetDimensions(
+          containerRef.current.clientWidth,
+          containerRef.current.clientHeight,
+          zoom
+        );
+      }
+    };
+
+    // Initial measurement
+    updateDimensions();
+
+    // ResizeObserver for container size changes
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        updateDimensions();
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    // Window resize listener for zoom changes
+    window.addEventListener("resize", updateDimensions);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateDimensions);
+      debouncedSetDimensions.cancel();
+    };
+  }, [debouncedSetDimensions]);
+
+  return [containerRef, dimensions];
+}

--- a/src/app/evaluations/evaluations-components/SingleModel/SingleModelHorizonPlot.tsx
+++ b/src/app/evaluations/evaluations-components/SingleModel/SingleModelHorizonPlot.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import React, {useEffect, useRef, useState} from "react";
+import React, { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
-import {subWeeks} from "date-fns";
+import { subWeeks } from "date-fns";
 
-import {modelColorMap} from "../../../Interfaces/modelColors";
+import { modelColorMap } from "../../../Interfaces/modelColors";
 import {
     DataPoint,
     isUTCDateEqual,
     ModelPrediction,
     PredictionDataPoint
 } from "../../../Interfaces/forecast-interfaces";
-import {useAppDispatch, useAppSelector} from "../../../store/hooks";
-import {useResponsiveSVG} from "../../../Interfaces/responsiveSVG";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { useResponsiveSVG } from "../../../Interfaces/responsiveSVG";
 
 interface HoverData {
     date: Date;
@@ -26,7 +26,7 @@ interface HoverData {
 
 
 const SingleModelHorizonPlot: React.FC = () => {
-    const {containerRef, dimensions, isResizing} = useResponsiveSVG();
+    const { containerRef, dimensions, isResizing } = useResponsiveSVG();
     const svgRef = useRef<SVGSVGElement>(null);
 
     // Track active event listeners for cleanup
@@ -196,7 +196,7 @@ const SingleModelHorizonPlot: React.FC = () => {
                 return d3.format(".1f")(val);
             });
 
-        return {xScale, yScale, xAxis, yAxis};
+        return { xScale, yScale, xAxis, yAxis };
     }
 
     function findActualDataRange(
@@ -206,7 +206,8 @@ const SingleModelHorizonPlot: React.FC = () => {
         state: string,
         dateRange: [Date, Date]
     ): [Date, Date] {
-        // Filter ground truth data for valid entries (admissions >= 0)
+
+        // Filter ground truth data for valid entries (with valid admissions, including placeholders)
         const validGroundTruth = groundTruthData.filter(d =>
             d.stateNum === state &&
             d.admissions >= -1 &&
@@ -216,13 +217,14 @@ const SingleModelHorizonPlot: React.FC = () => {
 
         // Get the model's prediction data
         const modelPrediction = predictionsData.find(model => model.modelName === modelName);
+        // Check each date for valid predictions, only dates with predictions are included
         const validPredictions = modelPrediction?.predictionData.filter(d =>
             d.stateNum === state &&
             d.referenceDate >= dateRange[0] &&
             d.referenceDate <= dateRange[1]
         ) || [];
 
-        // Find the earliest and latest dates with actual data
+        // Find the earliest and latest dates with actual data, only those that both have valid admission value & has predictions made on that day
         const startDates = [
             validGroundTruth.length > 0 ? validGroundTruth[0].date : dateRange[1],
             validPredictions.length > 0 ? validPredictions[0].referenceDate : dateRange[1]
@@ -233,6 +235,7 @@ const SingleModelHorizonPlot: React.FC = () => {
             validPredictions.length > 0 ? validPredictions[validPredictions.length - 1].referenceDate : dateRange[0]
         ];
 
+        // Use max and min to cut the ones missing prediction/admission, and we end up with range with actual concrete data values
         return [
             new Date(Math.max(...startDates.map(d => d.getTime()))),
             new Date(Math.min(...endDates.map(d => d.getTime())))
@@ -296,7 +299,7 @@ const SingleModelHorizonPlot: React.FC = () => {
         }
 
         // Create scales and chart group
-        const {xScale, yScale, xAxis, yAxis} = createScalesAndAxes(
+        const { xScale, yScale, xAxis, yAxis } = createScalesAndAxes(
             filteredGroundTruth,
             visualizationData,
             chartWidth,

--- a/src/app/evaluations/evaluations-components/SingleModel/SingleModelScoreLineChart.tsx
+++ b/src/app/evaluations/evaluations-components/SingleModel/SingleModelScoreLineChart.tsx
@@ -1,8 +1,11 @@
-import React, {useEffect, useRef} from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
-import {useAppSelector} from '../../../store/hooks';
-import {isUTCDateEqual} from '../../../Interfaces/forecast-interfaces';
-import {useResponsiveSVG} from "../../../Interfaces/responsiveSVG";
+
+import { useAppSelector } from '../../../store/hooks';
+
+import { DataPoint, isUTCDateEqual, ModelPrediction } from '../../../Interfaces/forecast-interfaces';
+import { useResponsiveSVG } from "../../../Interfaces/responsiveSVG";
+import { modelColorMap } from "../../../Interfaces/modelColors";
 
 interface ScoreDataPoint {
     referenceDate: Date;
@@ -10,468 +13,606 @@ interface ScoreDataPoint {
 }
 
 const SingleModelScoreLineChart: React.FC = () => {
-        const {containerRef, dimensions, isResizing} = useResponsiveSVG();
-        const chartRef = useRef<SVGSVGElement>(null);
+    const { containerRef, dimensions, isResizing } = useResponsiveSVG();
+    const chartRef = useRef<SVGSVGElement>(null);
+    const isDraggingRef = useRef(false);
 
-        // Get data and settings from Redux
-        const evaluationsScoreData = useAppSelector((state) => state.evaluationsSingleModelScoreData.data);
-        const {
-            evaluationSingleModelViewModel,
-            evaluationsSingleModelViewSelectedStateCode,
-            evaluationsSingleModelViewDateStart,
-            evaluationSingleModelViewDateEnd,
-            evaluationSingleModelViewScoresOption,
-            evaluationSingleModelViewHorizon
-        } = useAppSelector((state) => state.evaluationsSingleModelSettings);
+    // Get the ground and prediction data from store
+    const groundTruthData = useAppSelector((state) => state.groundTruth.data);
+    // console.debug("DEBUG: SingleModelHorizonPlot.tsx: groundTruthData", groundTruthData);
 
-        /* NOTE: All scoring options use the same color for now */
-        const chartColor = '#4a9eff';
+    const predictionsData = useAppSelector((state) => state.predictions.data);
+    // Get data and settings from Redux
+    const evaluationsScoreData = useAppSelector((state) => state.evaluationsSingleModelScoreData.data);
+    const {
+        evaluationSingleModelViewModel,
+        evaluationsSingleModelViewSelectedStateCode,
+        evaluationsSingleModelViewDateStart,
+        evaluationSingleModelViewDateEnd,
+        evaluationSingleModelViewScoresOption,
+        evaluationSingleModelViewHorizon
+    } = useAppSelector((state) => state.evaluationsSingleModelSettings);
 
-        function findActualDateRange(data: any[]): [Date, Date] {
-            if (!data || data.length === 0) return [evaluationsSingleModelViewDateStart, evaluationSingleModelViewDateEnd];
+    function findActualDataRange(
+        groundTruthData: DataPoint[],
+        predictionsData: ModelPrediction[],
+        modelName: string,
+        state: string,
+        dateRange: [Date, Date]
+    ): [Date, Date] {
 
-            const validDates = data
-                .filter(d => d.score !== undefined && !isNaN(d.score))
-                .map(d => d.referenceDate);
-
-            const start = new Date(Math.max(
-                d3.min(validDates) || evaluationsSingleModelViewDateStart.getTime(),
-                evaluationsSingleModelViewDateStart.getTime()
-            ));
-            const end = new Date(Math.min(
-                d3.max(validDates) || evaluationSingleModelViewDateEnd.getTime(),
-                evaluationSingleModelViewDateEnd.getTime()
-            ));
-
-            return [start, end];
-        }
-
-        function createInteractiveElements(
-            svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
-            margin: { top: number; right: number; bottom: number; left: number },
-            chartWidth: number,
-            chartHeight: number
-        ) {
-            // Mouse follow line
-            const mouseFollowLine = svg.append('line')
-                .attr('class', 'mouse-follow-line')
-                .attr('stroke', 'gray')
-                .attr('stroke-width', 1)
-                .attr('stroke-dasharray', '5,5')
-                .attr('y1', margin.top)
-                .attr('y2', chartHeight + margin.top)
-                .style('opacity', 0);
-
-            // Vertical indicator group
-            const indicatorGroup = svg.append('g')
-                .attr('class', 'vertical-indicator-group')
-                .style('opacity', 0);
-
-            indicatorGroup.append('line')
-                .attr('class', 'vertical-indicator')
-                .attr('stroke', 'lightgray')
-                .attr('stroke-width', 2)
-                .attr('y1', margin.top)
-                .attr('y2', chartHeight + margin.top);
-
-            const dateLabel = indicatorGroup.append('text')
-                .attr('class', 'date-label')
-                .attr('fill', 'white')
-                .attr('font-size', '12px')
-                .style('font-family', 'var(--font-dm-sans)')
-                .attr('y', margin.top + 20);
-
-            // Corner tooltip
-            const cornerTooltip = svg.append('g')
-                .attr('class', 'corner-tooltip')
-                .style('opacity', 0);
-
-            // Event capture area
-            const eventOverlay = svg.append('rect')
-                .attr('class', 'event-overlay')
-                .attr('x', margin.left)
-                .attr('y', margin.top)
-                .attr('width', chartWidth)
-                .attr('height', chartHeight)
-                .style('fill', 'none')
-                .style('pointer-events', 'all');
-
-            return {
-                mouseFollowLine,
-                indicatorGroup,
-                dateLabel,
-                cornerTooltip,
-                eventOverlay
-            };
-        }
-
-        function updateCornerTooltip(
-            tooltip: d3.Selection<SVGGElement, unknown, null, undefined>,
-            data: ScoreDataPoint,
-            isRightSide: boolean,
-            chartWidth: number,
-            scoreOption: string
-        ) {
-            tooltip.selectAll('*').remove();
-
-            const padding = 12;
-            const background = tooltip.append('rect')
-                .attr('fill', '#333943')
-                .attr('rx', 8)
-                .attr('ry', 8);
-
-            const dateText = tooltip.append('text')
-                .attr('x', padding)
-                .attr('y', padding + 12)
-                .attr('fill', 'white')
-                .attr('font-weight', 'bold')
-                .style('font-family', 'var(--font-dm-sans)')
-                .text(`Date: ${data.referenceDate.toUTCString().slice(5, 16)}`);
-
-            const scoreText = tooltip.append('text')
-                .attr('x', padding)
-                .attr('y', padding + 36)
-                .attr('fill', 'white')
-                .style('font-family', 'var(--font-dm-sans)')
-                .text(`${scoreOption}: ${scoreOption === 'MAPE' ?
-                    `${data.score.toFixed(1)}%` :
-                    data.score.toFixed(3)}`);
-
-            const textWidth = Math.max(
-                dateText.node()!.getComputedTextLength(),
-                scoreText.node()!.getComputedTextLength()
-            );
-
-            background
-                .attr('width', textWidth + padding * 2)
-                .attr('height', 60);
-
-            const tooltipX = isRightSide ?
-                chartWidth - textWidth - padding * 2 - 10 :
-                10;
-
-            tooltip
-                .attr('transform', `translate(${tooltipX}, 10)`)
-                .style('opacity', 1);
-        }
-
-        function renderChart() {
-            if (!chartRef.current || !dimensions.width || !dimensions.height) return;
-            // if (!chartRef.current) return;
-
-            const svg = d3.select(chartRef.current);
-            svg.selectAll('*').remove();
-
-            // Get dimensions and set margins
-            const width = dimensions.width;
-            const height = dimensions.height;
-
-            const margin = {
-                top: height * 0.02,
-                right: width * 0.03,
-                bottom: height * 0.15,
-                left: width * 0.04  // Increased for axis labels
-            };
-
-            const chartWidth = width - margin.left - margin.right;
-            const chartHeight = height - margin.top - margin.bottom;
-
-            // Filter data
-            const filteredData = evaluationsScoreData
-                .find(d => d.modelName === evaluationSingleModelViewModel &&
-                    d.scoreMetric === evaluationSingleModelViewScoresOption)
-                ?.scoreData.filter(d =>
-                    d.location === evaluationsSingleModelViewSelectedStateCode &&
-                    d.referenceDate >= evaluationsSingleModelViewDateStart &&
-                    d.referenceDate <= evaluationSingleModelViewDateEnd &&
-                    d.horizon == evaluationSingleModelViewHorizon
-                ) || [];
-
-            console.debug("Evaluations: SingleModelScoreLineChart.tsx: renderChart(): filteredData after applying all filters: ", filteredData);
-
-            if (filteredData.length === 0) {
-                svg.append('text')
-                    .attr('x', width / 2)
-                    .attr('y', height / 2)
-                    .attr('text-anchor', 'middle')
-                    .attr('fill', 'white')
-                    .style('font-family', 'var(--font-dm-sans)')
-                    .text('No score data available for selected criteria');
-                return;
-            }
-
-            // Find actual date range
-            const [actualStart, actualEnd] = findActualDateRange(filteredData);
-
-            // Create scales
-            const xScale = d3.scaleTime()
-                .domain([actualStart, actualEnd])
-                .range([0, chartWidth]);
-
-            // Calculate y-scale domain
-            const scores = filteredData.map(d => d.score);
-            const minScore = Math.min(...scores);
-            const maxScore = Math.max(...scores);
-            const yDomain = [0, maxScore * 1.02]
-            // const yDomain = evaluationSingleModelViewScoresOption === 'MAPE' ?
-            //     [0, maxScore * 1.1] :  // For MAPE, start at 0
-            //     [Math.min(minScore, 1.0 - (maxScore - 1.0)),
-            //         Math.max(maxScore, 1.0 + (1.0 - minScore))]; // For WIS_ratio, center around 1.0
-
-            const yScale = d3.scaleLinear()
-                .domain(yDomain)
-                .range([chartHeight, 0])
-                .nice();
-
-            // Create chart group
-            const chart = svg
-                .append('g')
-                .attr('transform', `translate(${margin.left},${margin.top})`);
-
-            // Draw reference line at y = 1 for WIS_ratio
-            if (evaluationSingleModelViewScoresOption === 'WIS_Ratio') {
-                chart.append('line')
-                    .attr('x1', 0)
-                    .attr('x2', chartWidth)
-                    .attr('y1', yScale(1))
-                    .attr('y2', yScale(1))
-                    .attr('stroke', 'white')
-                    .attr('stroke-width', 1)
-                    .attr('stroke-dasharray', '4,4')
-                    .attr('opacity', 0.5);
-            }
-
-            // Create line
-            const line = d3.line<any>()
-                .defined(d => !isNaN(d.score))
-                .x(d => xScale(d.referenceDate))
-                .y(d => yScale(d.score));
-
-            // Draw line
-            chart.append('path')
-                .datum(filteredData)
-                .attr('fill', 'none')
-                .attr('stroke', chartColor)
-                .attr('stroke-width', 2)
-                .attr('d', line);
-
-            // Draw points
-            chart.selectAll('circle')
-                .data(filteredData)
-                .enter()
-                .append('circle')
-                .attr('cx', d => xScale(d.referenceDate))
-                .attr('cy', d => yScale(d.score))
-                .attr('r', 4)
-                .attr('fill', chartColor);
-
-            // Create axes
-            const xAxis = d3.axisBottom(xScale)
-                .tickValues(d3.timeDay.range(actualStart, actualEnd, 7))
-                .tickFormat((d: Date) => {
-                    const month = d3.timeFormat('%b')(d);
-                    const day = d3.timeFormat('%d')(d);
-                    const isFirst = isUTCDateEqual(d, actualStart);
-                    const isFirstTickInNewMonth = d.getDate() < 7 && d.getDate() > 0;
-                    const isNearYearChange = d.getMonth() === 0 && d.getDate() <= 7;
-
-
-                    // Adjust label format based on chart width
-                    if (chartWidth < 500) {
-                        // Small width mode: show month only on first day of month, first tick, and near year change
-                        if (isFirst || isFirstTickInNewMonth || isNearYearChange) {
-                            return month;
-                        } else {
-                            return '';
-                        }
-                    } else {
-                        // Normal width mode: show day for every tick, month on first day of month, first tick, and near year change
-                        if (isFirst || isFirstTickInNewMonth || isNearYearChange) {
-                            return `${month}\n${day}`;
-                        } else {
-                            return day;
-                        }
-                    }
-                });
-
-            const yAxis = d3.axisLeft(yScale)
-                .tickFormat((d: number) => {
-                    if (evaluationSingleModelViewScoresOption === 'MAPE') {
-                        return d >= 10 ? `${d.toFixed(0)}%` : `${d.toFixed(1)}%`;
-                    } else {
-                        return d.toFixed(1);
-                    }
-                });
-
-
-            /* Helper function to wrap x-axis label*/
-            function wrap(text, width) {
-                text.each(function () {
-                    var text = d3.select(this), words = text.text().split(/\n+/).reverse(), word, line = [], lineNumber = 0,
-                        lineHeight = 1.0, // ems
-                        y = text.attr("y"), dy = parseFloat(text.attr("dy")), tspan = text
-                            .text(null)
-                            .append("tspan")
-                            .attr("x", 0)
-                            .attr("y", y)
-                            .attr("dy", dy + "em");
-                    while ((word = words.pop())) {
-                        line.push(word);
-                        tspan.text(line.join(" "));
-                        if (tspan.node().getComputedTextLength() > width) {
-                            line.pop();
-                            tspan.text(line.join(" "));
-                            line = [word];
-                            tspan = text
-                                .append("tspan")
-                                .attr("x", 0)
-                                .attr("y", 0)
-                                .attr("dy", ++lineNumber * lineHeight + dy + "em")
-                                .text(word);
-                        }
-                    }
-                });
-            }
-
-
-            // Add axes
-            chart.append('g')
-                .attr('transform', `translate(0,${chartHeight})`)
-                .style('font-family', 'var(--font-dm-sans)')
-                .call(xAxis)
-                .selectAll('text')
-                .style("text-anchor", "middle")
-                .style('font-size', '13px')
-                .call(wrap, 20); // 32 is the minimum width to accommodate year number at 1080p 100% zoom view environment, adjust as needed;
-
-
-            chart.append('g')
-                .style('font-family', 'var(--font-dm-sans)')
-                .call(yAxis)
-                .call(g => g.select('.domain').remove())
-                .call(g => g.selectAll('.tick line')
-                    .attr('stroke-opacity', 0.5)
-                    .attr('stroke-dasharray', '2,2')
-                    .attr('x2', chartWidth))
-                .style('font-size', '18px');
-
-            // Add interactivity
-            const {
-                mouseFollowLine,
-                indicatorGroup,
-                dateLabel,
-                cornerTooltip,
-                eventOverlay
-            } = createInteractiveElements(svg, margin, chartWidth, chartHeight);
-
-            // Add interaction handlers
-            let isDragging = false;
-
-            function findClosestDataPoint(mouseX: number): ScoreDataPoint | null {
-                const date = xScale.invert(mouseX - margin.left);
-                const bisect = d3.bisector((d: ScoreDataPoint) => d.referenceDate).left;
-                const index = bisect(filteredData, date);
-
-                if (index >= filteredData.length) return filteredData[filteredData.length - 1];
-                if (index === 0) return filteredData[0];
-
-                const left = filteredData[index - 1];
-                const right = filteredData[index];
-
-                return date.getTime() - left.referenceDate.getTime() >
-                right.referenceDate.getTime() - date.getTime() ? right : left;
-            }
-
-            function updateVisuals(event: any) {
-                const [mouseX] = d3.pointer(event);
-                const dataPoint = findClosestDataPoint(mouseX);
-
-                if (!dataPoint) return;
-
-                const xPos = xScale(dataPoint.referenceDate) + margin.left;
-                const isRightSide = mouseX < chartWidth / 2;
-
-                mouseFollowLine
-                    .attr('transform', `translate(${xPos}, 0)`)
-                    .style('opacity', 1);
-
-                if (isDragging) {
-                    indicatorGroup
-                        .attr('transform', `translate(${xPos}, 0)`)
-                        .style('opacity', 1);
-
-                    dateLabel
-                        .attr('x', isRightSide ? 5 : -5)
-                        .attr('text-anchor', isRightSide ? 'start' : 'end')
-                        .text(dataPoint.referenceDate.toUTCString().slice(5, 16));
-                }
-
-                updateCornerTooltip(
-                    cornerTooltip,
-                    dataPoint,
-                    isRightSide,
-                    chartWidth,
-                    evaluationSingleModelViewScoresOption
-                );
-            }
-
-            eventOverlay
-                .on('mousemove', updateVisuals)
-                .on('mouseout', () => {
-                    mouseFollowLine.style('opacity', 0);
-                    cornerTooltip.style('opacity', 0);
-                    isDragging = false; // Reset drag state when mouse leaves
-                    indicatorGroup.style('opacity', 0); // Hide indicator when mouse leaves
-                })
-                .on('mousedown', (event) => {
-                    isDragging = true;
-                    // Immediately update visuals when clicking
-                    updateVisuals(event);
-                    indicatorGroup.style('opacity', 1);
-                })
-                .on('mouseup', () => {
-                    isDragging = false;
-                })
-                // Add global mouse up handler in case mouse is released outside chart
-                .on('mouseleave', () => {
-                    isDragging = false;
-                });
-        }
-
-        useEffect(() => {
-                if (!isResizing && dimensions.width > 0 && dimensions.height > 0) {
-                    renderChart();
-                }
-            }, [
-                dimensions,
-                isResizing,
-                evaluationSingleModelViewModel,
-                evaluationsSingleModelViewSelectedStateCode,
-                evaluationsSingleModelViewDateStart,
-                evaluationSingleModelViewDateEnd,
-                evaluationSingleModelViewScoresOption,
-                evaluationSingleModelViewHorizon,
-                evaluationsScoreData
-            ]
+        // Filter ground truth data for valid entries (with valid admissions, including placeholders)
+        const validGroundTruth = groundTruthData.filter(d =>
+            d.stateNum === state &&
+            d.admissions >= -1 &&
+            d.date >= dateRange[0] &&
+            d.date <= dateRange[1]
         );
 
-        return (
-            <div ref={containerRef} className="w-full h-full">
-                <svg
-                    ref={chartRef}
-                    width="100%"
-                    height="100%"
-                    className="w-full h-full"
-                    style={{
-                        fontFamily: "var(--font-dm-sans)",
-                        visibility: isResizing ? 'hidden' : 'visible'
-                    }}
-                    viewBox={`0 0 ${dimensions.width || 100} ${dimensions.height || 100}`}
-                    preserveAspectRatio="xMidYMid meet"
-                />
-            </div>
+        // Get the model's prediction data
+        const modelPrediction = predictionsData.find(model => model.modelName === modelName);
+        // Check each date for valid predictions, only dates with predictions are included
+        const validPredictions = modelPrediction?.predictionData.filter(d =>
+            d.stateNum === state &&
+            d.referenceDate >= dateRange[0] &&
+            d.referenceDate <= dateRange[1]
+        ) || [];
+
+        // Find the earliest and latest dates with actual data, only those that both have valid admission value & has predictions made on that day
+        const startDates = [
+            validGroundTruth.length > 0 ? validGroundTruth[0].date : dateRange[1],
+            validPredictions.length > 0 ? validPredictions[0].referenceDate : dateRange[1]
+        ];
+
+        const endDates = [
+            validGroundTruth.length > 0 ? validGroundTruth[validGroundTruth.length - 1].date : dateRange[0],
+            validPredictions.length > 0 ? validPredictions[validPredictions.length - 1].referenceDate : dateRange[0]
+        ];
+
+        // Use max and min to cut the ones missing prediction/admission, and we end up with range with actual concrete data values
+        return [
+            new Date(Math.max(...startDates.map(d => d.getTime()))),
+            new Date(Math.min(...endDates.map(d => d.getTime())))
+        ];
+    }
+
+    function createInteractiveElements(
+        svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+        margin: { top: number; right: number; bottom: number; left: number },
+        chartWidth: number,
+        chartHeight: number
+    ) {
+        // Mouse follow line
+        const mouseFollowLine = svg.append('line')
+            .attr('class', 'mouse-follow-line')
+            .attr('stroke', 'gray')
+            .attr('stroke-width', 1)
+            .attr('stroke-dasharray', '5,5')
+            .attr('y1', margin.top)
+            .attr('y2', chartHeight + margin.top)
+            .style('opacity', 0);
+
+        // Vertical indicator group
+        const indicatorGroup = svg.append('g')
+            .attr('class', 'vertical-indicator-group')
+            .style('opacity', 0);
+
+        indicatorGroup.append('line')
+            .attr('class', 'vertical-indicator')
+            .attr('stroke', 'lightgray')
+            .attr('stroke-width', 2)
+            .attr('y1', margin.top)
+            .attr('y2', chartHeight + margin.top);
+
+        const dateLabel = indicatorGroup.append('text')
+            .attr('class', 'date-label')
+            .attr('fill', 'white')
+            .attr('font-size', '12px')
+            .style('font-family', 'var(--font-dm-sans)')
+            .attr('y', margin.top + 20);
+
+        // Corner tooltip
+        const cornerTooltip = svg.append('g')
+            .attr('class', 'corner-tooltip')
+            .style('opacity', 0);
+
+        // Event capture area
+        const eventOverlay = svg.append('rect')
+            .attr('class', 'event-overlay')
+            .attr('x', margin.left)
+            .attr('y', margin.top)
+            .attr('width', chartWidth)
+            .attr('height', chartHeight)
+            .style('fill', 'none')
+            .style('pointer-events', 'all');
+
+        return {
+            mouseFollowLine,
+            indicatorGroup,
+            dateLabel,
+            cornerTooltip,
+            eventOverlay
+        };
+    }
+
+    function updateCornerTooltip(
+        tooltip: d3.Selection<SVGGElement, unknown, null, undefined>,
+        data: ScoreDataPoint,
+        isRightSide: boolean,
+        chartWidth: number,
+        scoreOption: string
+    ) {
+        tooltip.selectAll('*').remove();
+
+        const padding = 12;
+        const background = tooltip.append('rect')
+            .attr('fill', '#333943')
+            .attr('rx', 8)
+            .attr('ry', 8);
+
+        const dateText = tooltip.append('text')
+            .attr('x', padding)
+            .attr('y', padding + 12)
+            .attr('fill', 'white')
+            .attr('font-weight', 'bold')
+            .style('font-family', 'var(--font-dm-sans)')
+            .text(`Date: ${data.referenceDate.toUTCString().slice(5, 16)}`);
+
+        const scoreText = tooltip.append('text')
+            .attr('x', padding)
+            .attr('y', padding + 36)
+            .attr('fill', 'white')
+            .style('font-family', 'var(--font-dm-sans)')
+            .text(`${scoreOption}: ${scoreOption === 'MAPE' ?
+                `${data.score.toFixed(1)}%` :
+                data.score.toFixed(3)}`);
+
+        const textWidth = Math.max(
+            dateText.node()!.getComputedTextLength(),
+            scoreText.node()!.getComputedTextLength()
+        );
+
+        background
+            .attr('width', textWidth + padding * 2)
+            .attr('height', 60);
+
+        const tooltipX = isRightSide ?
+            chartWidth - textWidth - padding * 2 - 10 :
+            10;
+
+        tooltip
+            .attr('transform', `translate(${tooltipX}, 10)`)
+            .style('opacity', 1);
+    }
+
+    function generateSaturdayDates(startDate: Date, endDate: Date): Date[] {
+        const dates: Date[] = [];
+        let currentDate = new Date(startDate);
+
+        // Move to the first Saturday if not already on one
+        while (currentDate.getDay() !== 6) {
+            currentDate.setDate(currentDate.getDate() + 1);
+        }
+
+        // Generate all Saturdays until end date
+        while (currentDate <= endDate) {
+            dates.push(new Date(currentDate));
+            currentDate.setDate(currentDate.getDate() + 7);
+        }
+
+        return dates;
+    }
+
+    function findClosestDataPoint(mouseX: number, xScale: d3.ScaleBand<string>, margin: any, filteredData: ScoreDataPoint[]): ScoreDataPoint | null {
+
+        if (filteredData.length === 0) return null;
+
+        // Adjust mouseX to account for margin
+        const adjustedX = mouseX - margin.left;
+
+        // Get all the dates in our scale
+        const dates = xScale.domain().map(dateStr => new Date(dateStr));
+
+        // Find the closest date based on x position
+        const bandWidth = xScale.bandwidth();
+        const step = xScale.step();
+        const index = Math.floor(adjustedX / step);
+
+        // Ensure we're within bounds
+        if (index < 0) return filteredData[0];
+        if (index >= dates.length) return filteredData[filteredData.length - 1];
+
+        // Find the actual data point closest to this date
+        const targetDate = dates[index];
+        return filteredData.reduce((closest, current) => {
+            if (!closest) return current;
+
+            const closestDiff = Math.abs(closest.referenceDate.getTime() - targetDate.getTime());
+            const currentDiff = Math.abs(current.referenceDate.getTime() - targetDate.getTime());
+
+            return currentDiff < closestDiff ? current : closest;
+        }, null as ScoreDataPoint | null);
+    }
+    function createScalesAndAxes(
+        saturdayDates: Date[],
+        filteredData: ScoreDataPoint[],
+        chartWidth: number,
+        chartHeight: number,
+        actualStart: Date,
+        scoreOption: string
+    ) {
+        // Create band scale for x-axis
+        const xScale = d3.scaleBand()
+            .domain(saturdayDates.map(d => d.toISOString()))
+            .range([0, chartWidth])
+            .padding(0.1);
+
+        // Calculate y-scale domain
+        const scores = filteredData.map(d => d.score);
+        const maxScore = Math.max(...scores);
+        const yDomain = [0, maxScore * 1.02];
+
+        const yScale = d3.scaleLinear()
+            .domain(yDomain)
+            .range([chartHeight, 0])
+            .nice();
+
+        // Create axes
+        const xAxis = d3.axisBottom(xScale)
+            .tickValues(saturdayDates.map(d => d.toISOString()))
+            .tickFormat((d: string) => {
+                const date = new Date(d);
+                const month = d3.timeFormat('%b')(date);
+                const day = d3.timeFormat('%d')(date);
+                const isFirst = isUTCDateEqual(date, actualStart);
+                const isFirstTickInNewMonth = date.getDate() < 7 && date.getDate() > 0;
+                const isNearYearChange = date.getMonth() === 0 && date.getDate() <= 7;
+
+                if (chartWidth < 500) {
+                    if (isFirst || isFirstTickInNewMonth || isNearYearChange) {
+                        return month;
+                    }
+                    return '';
+                } else {
+                    if (isFirst || isFirstTickInNewMonth || isNearYearChange) {
+                        return `${month}\n${day}`;
+                    }
+                    return day;
+                }
+            });
+
+        const yAxis = d3.axisLeft(yScale)
+            .tickFormat((d: number) => {
+                if (scoreOption === 'MAPE') {
+                    return d >= 10 ? `${d.toFixed(0)}%` : `${d.toFixed(1)}%`;
+                }
+                return d.toFixed(1);
+            });
+
+        return { xScale, yScale, xAxis, yAxis };
+    }
+
+    function updateVisuals(event: any, {
+        mouseFollowLine,
+        indicatorGroup,
+        dateLabel,
+        cornerTooltip,
+        xScale,
+        margin,
+        chartWidth,
+        filteredData,
+        isDragging
+    }: {
+        mouseFollowLine: d3.Selection<SVGLineElement, unknown, null, undefined>;
+        indicatorGroup: d3.Selection<SVGGElement, unknown, null, undefined>;
+        dateLabel: d3.Selection<SVGTextElement, unknown, null, undefined>;
+        cornerTooltip: d3.Selection<SVGGElement, unknown, null, undefined>;
+        xScale: d3.ScaleBand<string>;
+        margin: { top: number; right: number; bottom: number; left: number };
+        chartWidth: number;
+        filteredData: ScoreDataPoint[];
+        isDragging: boolean;
+    }) {
+        const [mouseX] = d3.pointer(event);
+        const dataPoint = findClosestDataPoint(mouseX, xScale, margin, filteredData);
+
+        if (!dataPoint) return;
+
+        // Calculate position using the band scale
+        const xPos = (xScale(dataPoint.referenceDate.toISOString()) || 0) + xScale.bandwidth() / 2 + margin.left;
+        const isRightSide = mouseX < chartWidth / 2;
+
+        mouseFollowLine
+            .attr('transform', `translate(${xPos}, 0)`)
+            .style('opacity', 1);
+
+        if (isDragging) {
+            indicatorGroup
+                .attr('transform', `translate(${xPos}, 0)`)
+                .style('opacity', 1);
+
+            dateLabel
+                .attr('x', isRightSide ? 5 : -5)
+                .attr('text-anchor', isRightSide ? 'start' : 'end')
+                .text(dataPoint.referenceDate.toUTCString().slice(5, 16));
+        }
+
+        updateCornerTooltip(
+            cornerTooltip,
+            dataPoint,
+            isRightSide,
+            chartWidth,
+            evaluationSingleModelViewScoresOption
         );
     }
-;
+
+    function renderVisualElements(
+        chart: d3.Selection<SVGGElement, unknown, null, undefined>,
+        filteredData: ScoreDataPoint[],
+        xScale: d3.ScaleBand<string>,
+        yScale: d3.ScaleLinear<number, number>,
+        modelName: string,
+        scoreOption: string
+    ) {
+        // Draw reference line at y = 1 for WIS_ratio
+        if (scoreOption === 'WIS_Ratio') {
+            chart.append('line')
+                .attr('x1', 0)
+                .attr('x2', xScale.range()[1])
+                .attr('y1', yScale(1))
+                .attr('y2', yScale(1))
+                .attr('stroke', 'white')
+                .attr('stroke-width', 1)
+                .attr('stroke-dasharray', '4,4')
+                .attr('opacity', 0.5);
+        }
+
+        // Create container for all visual elements
+        const visualContainer = chart.append('g')
+            .attr('class', 'visual-container');
+
+        // Create specific groups for different visual elements
+        const linesGroup = visualContainer.append('g').attr('class', 'lines');
+        const pointsGroup = visualContainer.append('g').attr('class', 'points');
+
+        // Modified line generator
+        const line = d3.line<ScoreDataPoint>()
+            .defined(d => !isNaN(d.score))
+            .x(d => (xScale(d.referenceDate.toISOString()) || 0) + xScale.bandwidth() / 2)
+            .y(d => yScale(d.score));
+
+        // Draw line
+        linesGroup.append('path')
+            .datum(filteredData)
+            .attr('fill', 'none')
+            .attr('stroke', modelColorMap[modelName])
+            .attr('stroke-width', 2)
+            .attr('d', line);
+
+        // Draw points
+        pointsGroup.selectAll('circle')
+            .data(filteredData)
+            .enter()
+            .append('circle')
+            .attr('cx', d => (xScale(d.referenceDate.toISOString()) || 0) + xScale.bandwidth() / 2)
+            .attr('cy', d => yScale(d.score))
+            .attr('r', 4)
+            .attr('fill', modelColorMap[modelName]);
+    }
+
+    function renderChart() {
+        if (!chartRef.current || !dimensions.width || !dimensions.height) return;
+
+        const svg = d3.select(chartRef.current);
+        svg.selectAll('*').remove();
+
+        // Setup dimensions
+        const width = dimensions.width;
+        const height = dimensions.height;
+        const margin = {
+            top: height * 0.02,
+            right: width * 0.03,
+            bottom: height * 0.15,
+            left: width * 0.04
+        };
+        const chartWidth = width - margin.left - margin.right;
+        const chartHeight = height - margin.top - margin.bottom;
+
+        // Get data range and prepare data
+        const [actualStart, actualEnd] = findActualDataRange(
+            groundTruthData,
+            predictionsData,
+            evaluationSingleModelViewModel,
+            evaluationsSingleModelViewSelectedStateCode,
+            [evaluationsSingleModelViewDateStart, evaluationSingleModelViewDateEnd]
+        );
+
+        const saturdayDates = generateSaturdayDates(actualStart, actualEnd);
+
+        const filteredData = evaluationsScoreData
+            .find(d => d.modelName === evaluationSingleModelViewModel &&
+                d.scoreMetric === evaluationSingleModelViewScoresOption)
+            ?.scoreData.filter(d =>
+                d.location === evaluationsSingleModelViewSelectedStateCode &&
+                d.referenceDate >= actualStart &&
+                d.referenceDate <= actualEnd &&
+                d.horizon == evaluationSingleModelViewHorizon
+            ) || [];
+
+        // Handle when no data is present: just display a information
+        if (filteredData.length === 0) {
+            svg.append('text')
+                .attr('x', width / 2)
+                .attr('y', height / 2)
+                .attr('text-anchor', 'middle')
+                .attr('fill', 'white')
+                .style('font-family', 'var(--font-dm-sans)')
+                .text('No score data available for selected criteria');
+            return;
+        }
+
+        // Create scales and axes
+        const { xScale, yScale, xAxis, yAxis } = createScalesAndAxes(
+            saturdayDates,
+            filteredData,
+            chartWidth,
+            chartHeight,
+            actualStart,
+            evaluationSingleModelViewScoresOption
+        );
+
+        // Create main chart group
+        const chart = svg
+            .append('g')
+            .attr('transform', `translate(${margin.left},${margin.top})`);
+
+        // Render visual elements
+        renderVisualElements(
+            chart,
+            filteredData,
+            xScale,
+            yScale,
+            evaluationSingleModelViewModel,
+            evaluationSingleModelViewScoresOption
+        );
+        /* Helper function to wrap x-axis label*/
+        function wrap(text, width) {
+            text.each(function () {
+                var text = d3.select(this), words = text.text().split(/\n+/).reverse(), word, line = [], lineNumber = 0,
+                    lineHeight = 1.0, // ems
+                    y = text.attr("y"), dy = parseFloat(text.attr("dy")), tspan = text
+                        .text(null)
+                        .append("tspan")
+                        .attr("x", 0)
+                        .attr("y", y)
+                        .attr("dy", dy + "em");
+                while ((word = words.pop())) {
+                    line.push(word);
+                    tspan.text(line.join(" "));
+                    if (tspan.node().getComputedTextLength() > width) {
+                        line.pop();
+                        tspan.text(line.join(" "));
+                        line = [word];
+                        tspan = text
+                            .append("tspan")
+                            .attr("x", 0)
+                            .attr("y", 0)
+                            .attr("dy", ++lineNumber * lineHeight + dy + "em")
+                            .text(word);
+                    }
+                }
+            });
+        }
+
+        // Add axes with styling
+        chart.append('g')
+            .attr('transform', `translate(0,${chartHeight})`)
+            .style('font-family', 'var(--font-dm-sans)')
+            .call(xAxis)
+            .selectAll('text')
+            .style('text-anchor', 'middle')
+            .style('font-size', '13px')
+            .call(wrap, 20);
+
+        chart.append('g')
+            .style('font-family', 'var(--font-dm-sans)')
+            .call(yAxis)
+            .call(g => g.select('.domain').remove())
+            .call(g => g.selectAll('.tick line')
+                .attr('stroke-opacity', 0.5)
+                .attr('stroke-dasharray', '2,2')
+                .attr('x2', chartWidth))
+            .style('font-size', '18px');
+
+        // Add interactivity
+        const interactiveElements = createInteractiveElements(svg, margin, chartWidth, chartHeight);
+        const { mouseFollowLine, indicatorGroup, dateLabel, cornerTooltip, eventOverlay } = interactiveElements;
+
+        // Add interaction handlers
+        let isDragging = isDraggingRef.current;
+
+        eventOverlay
+            .on('mousemove', (event) => {
+                const params = {
+                    mouseFollowLine,
+                    indicatorGroup,
+                    dateLabel,
+                    cornerTooltip,
+                    xScale,
+                    margin,
+                    chartWidth,
+                    filteredData,
+                    isDragging
+                };
+                updateVisuals(event, params);
+            })
+            .on('mouseout', () => {
+                mouseFollowLine.style('opacity', 0);
+                // cornerTooltip.style('opacity', 0);
+                isDragging = false;
+                // indicatorGroup.style('opacity', 0);
+            })
+            .on('mousedown', (event) => {
+                isDraggingRef.current = true;
+                isDragging = true;
+                const params = {
+                    mouseFollowLine,
+                    indicatorGroup,
+                    dateLabel,
+                    cornerTooltip,
+                    xScale,
+                    margin,
+                    chartWidth,
+                    filteredData,
+                    isDragging
+                };
+                updateVisuals(event, params);
+                indicatorGroup.style('opacity', 1);
+            })
+            .on('mouseup', () => {
+                isDragging = false;
+            })
+            .on('mouseleave', () => {
+                isDragging = false;
+            });
+
+        // Ensure tooltip is always on top
+        cornerTooltip.raise();
+    }
+
+    useEffect(() => {
+        if (!isResizing && dimensions.width > 0 && dimensions.height > 0) {
+            renderChart();
+        }
+    }, [
+        dimensions,
+        isResizing,
+        evaluationSingleModelViewModel,
+        evaluationsSingleModelViewSelectedStateCode,
+        evaluationsSingleModelViewDateStart,
+        evaluationSingleModelViewDateEnd,
+        evaluationSingleModelViewScoresOption,
+        evaluationSingleModelViewHorizon,
+        evaluationsScoreData
+    ]
+    );
+
+    return (
+        <div ref={containerRef} className="w-full h-full">
+            <svg
+                ref={chartRef}
+                width="100%"
+                height="100%"
+                className="w-full h-full"
+                style={{
+                    fontFamily: "var(--font-dm-sans)",
+                    visibility: isResizing ? 'hidden' : 'visible'
+                }}
+                viewBox={`0 0 ${dimensions.width || 100} ${dimensions.height || 100}`}
+                preserveAspectRatio="xMidYMid meet"
+            />
+        </div>
+    );
+};
 
 export default SingleModelScoreLineChart;

--- a/src/app/forecasts/forecasts-components/ForecastChart.tsx
+++ b/src/app/forecasts/forecasts-components/ForecastChart.tsx
@@ -1,12 +1,13 @@
 // src/app/Components/forecasts-components/ForecastChart.tsx
 "use client";
 
-import React, {useEffect, useRef, useState} from "react";
+import React, { useEffect, useRef, useState } from "react";
 import * as d3 from "d3";
-import {Axis, BaseType, NumberValue, ScaleLinear, ScaleLogarithmic, ScaleTime} from "d3";
-import {subWeeks} from "date-fns";
+import { Axis, BaseType, NumberValue, ScaleLinear, ScaleLogarithmic, ScaleTime } from "d3";
+import { subWeeks } from "date-fns";
 
-import {modelColorMap} from "../../Interfaces/modelColors";
+import { useChartMargins, calculateLabelSpace } from "../../Interfaces/chart-margin-utils";
+import { modelColorMap } from "../../Interfaces/modelColors";
 import {
     DataPoint,
     HistoricalDataEntry,
@@ -15,8 +16,8 @@ import {
     PredictionDataPoint
 } from "../../Interfaces/forecast-interfaces";
 
-import {useAppDispatch, useAppSelector} from "../../store/hooks";
-import {updateUserSelectedWeek} from "../../store/forecast-settings-slice";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { updateUserSelectedWeek } from "../../store/forecast-settings-slice";
 
 const ForecastChart: React.FC = () => {
 
@@ -320,7 +321,7 @@ const ForecastChart: React.FC = () => {
 
         yAxis.tickSize(-chartWidth);
 
-        return {xScale, yScale, xAxis, yAxis};
+        return { xScale, yScale, xAxis, yAxis };
     }
 
     function generateYAxisTicks(minValue: number, maxValue: number, isLogScale: boolean): number[] {
@@ -597,7 +598,7 @@ const ForecastChart: React.FC = () => {
         /* Change the accompaning tooltip text to DM Sans*/
 
 
-        return {group, line, tooltip};
+        return { group, line, tooltip };
     }
 
     function updateVerticalIndicator(date: Date, xScale: d3.ScaleTime<number, number>, marginLeft: number, chartWidth: number, group: d3.Selection<SVGGElement, unknown, null, undefined>, tooltip: d3.Selection<SVGTextElement, unknown, null, undefined>,) {
@@ -937,7 +938,7 @@ const ForecastChart: React.FC = () => {
         const {
             group: verticalIndicatorGroup, line: verticalIndicator, tooltip: lineTooltip,
         } = renderVerticalIndicator(svg, xScale, marginLeft, marginTop, height, marginBottom,);
-        const cornerTooltip = createCornerTooltip(svg, marginLeft, marginTop, );
+        const cornerTooltip = createCornerTooltip(svg, marginLeft, marginTop,);
         const eventOverlay = createEventOverlay(svg, marginLeft, marginTop, chartWidth, chartHeight,);
 
         let isDragging = false;
@@ -1036,7 +1037,7 @@ const ForecastChart: React.FC = () => {
             // Remove the existing chart elements
             svg.selectAll("*").remove();
 
-            const {marginTop, marginBottom, marginLeft, marginRight} = calculateMargins();
+            const { marginTop, marginBottom, marginLeft, marginRight } = calculateMargins();
 
             const chartWidth = width - marginLeft - marginRight;
             const chartHeight = height - marginTop - marginBottom;

--- a/src/app/providers/DataProvider.tsx
+++ b/src/app/providers/DataProvider.tsx
@@ -272,8 +272,6 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({children}
                     dispatch(updateEvaluationsSingleModelViewDateRange(lastSeason.timeValue));
                     dispatch(updateEvaluationSingleModelViewDateStart(lastSeason.startDate));
                     dispatch(updateEvaluationSingleModelViewDateEnd(lastSeason.endDate));
-
-
                 }
                 updateLoadingState('seasonOptions', false);
 

--- a/src/app/store/evaluations-single-model-settings-slice.ts
+++ b/src/app/store/evaluations-single-model-settings-slice.ts
@@ -11,7 +11,7 @@ interface EvaluationsSettingsState {
     /* Model Related*/
     evaluationSingleModelViewModel: string; //Single Model view page allows only 1 model to be selected at a time
     evaluationSingleModelViewHorizon: number; //how many weeks ahead from reference date (matching surveillance week's number) should we look for as target_end_date in predictions to draw the intervals
-    evaluationSingleModelViewScoresOption: any; //TODO: Implement after discussion
+    evaluationSingleModelViewScoresOption: any;
 
     /* Time Range Related */
     evaluationsSingleModelViewDateStart: Date;
@@ -67,8 +67,6 @@ const evaluationsSingleModelSettingsSlice = createSlice({
             // console.debug("DEBUG: Redux: evaluations-single-model-settings-slice.ts: updateEvaluationsSingleModelViewDateRange", action.payload);
             state.evaluationsSingleModelViewDateRange = action.payload;
         },
-
-        /*TODO: Implement reducer for scores once discussed*/
         updateEvaluationScores: (state, action: PayloadAction<any>) => {
             console.debug("DEBUG: Redux: evaluations-single-model-settings-slice.ts: updateEvaluationScores", action.payload);
             state.evaluationSingleModelViewScoresOption = action.payload;
@@ -84,7 +82,6 @@ export const {
     updateEvaluationSingleModelViewDateStart,
     updateEvaluationSingleModelViewDateEnd,
     updateEvaluationsSingleModelViewDateRange,
-    /* TODO: uncomment this after scores options are implemented */
     updateEvaluationScores
 } = evaluationsSingleModelSettingsSlice.actions;
 


### PR DESCRIPTION
- Updated evaluations single-model score chart to use a band scale for x-axis, and vertically aligned each date’s position to the horizon forecast chart above it
- Implemented a new experimental pattern for automatically resizing/update the display of svg charts (including forecast and evaluations) when zoom-level or window dimensions change; this is done on weekly hospitalization forecast chart but not yet on the evaluations charts, since this inadvertently changed how the left-border of chart aligns with other html elements on the page (see the weekly hospitalization chart’s y-axis labels). I need to further do some work on the CSS side as a result
- Double-checked demo branch to make sure pipeline runs fine, with epistorm-evaluations submodule updated to track main  properly
- finally anchored the epistorm logo on evaluations page