### PR TITLE
Release/v1.7.2 bug fix

### DIFF
--- a/src/app/forecasts/forecasts-components/ForecastChart.tsx
+++ b/src/app/forecasts/forecasts-components/ForecastChart.tsx
@@ -20,7 +20,7 @@ import {
   ModelPrediction,
   PredictionDataPoint,
 } from "@/interfaces/forecast-interfaces";
-import { useChartDimensions } from "@/interfaces/forecast-chart-dimension-observer";
+import { useResponsiveSVG } from "@/interfaces/responsiveSVG";
 import {
   useChartMargins,
   calculateLabelSpace,
@@ -1736,17 +1736,22 @@ const ForecastChart: React.FC = () => {
     isResizing,
     margins,
     groundTruthData,
+    historicalGroundTruthData,
     predictionsData,
     USStateNum,
     forecastModel,
     numOfWeeksAhead,
     dateStart,
+    historicalDataMode,
     dateEnd,
     yAxisScale,
     confidenceInterval,
-    historicalDataMode,
     userSelectedWeek,
-    historicalDataMode,
+    dispatch,
+    createScalesAndAxes,
+    renderChartComponents,
+    updateVerticalIndicator,
+    renderHistoricalData,
   ]);
 
   // Return the SVG object using reference
@@ -1761,8 +1766,8 @@ const ForecastChart: React.FC = () => {
         viewBox={`0 0 ${dimensions.width || 100} ${dimensions.height || 100}`}
         style={{
           fontFamily: "var(--font-dm-sans)",
-          opacity: isResizing ? 0.5 : 1,
-          transition: "opacity 0.1s ease",
+          opacity: isResizing ? 0.6 : 1,
+          transition: "opacity 0.005s ease",
         }}></svg>
     </div>
   );

--- a/src/app/forecasts/forecasts-components/ForecastChart.tsx
+++ b/src/app/forecasts/forecasts-components/ForecastChart.tsx
@@ -29,13 +29,18 @@ import { modelColorMap } from "@/interfaces/epistorm-constants";
 
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { updateUserSelectedWeek } from "@/store/forecast-settings-slice";
+import { useResponsiveSVG } from "@/interfaces/responsiveSVG";
 
 const ForecastChart: React.FC = () => {
   // reference to svg object
   const svgRef = useRef(null);
 
-  const [containerRef, { width, height, zoomLevel }] = useChartDimensions();
-  const margins = useChartMargins(width, height, "default");
+  const { containerRef, dimensions, isResizing } = useResponsiveSVG();
+  const margins = useChartMargins(
+    dimensions.width,
+    dimensions.height,
+    "default"
+  );
 
   // Get the ground and prediction data-slices from store
   const groundTruthData = useAppSelector((state) => state.groundTruth.data);
@@ -701,10 +706,10 @@ const ForecastChart: React.FC = () => {
               confidenceIntervalData.interval === "50"
                 ? 0.4
                 : confidenceIntervalData.interval === "90"
-                ? 0.2
-                : confidenceIntervalData.interval === "95"
-                ? 0.1
-                : 1;
+                  ? 0.2
+                  : confidenceIntervalData.interval === "95"
+                    ? 0.1
+                    : 1;
 
             const color = d3.color(modelColor);
             color.opacity = opacity;
@@ -1594,8 +1599,8 @@ const ForecastChart: React.FC = () => {
       // Remove the existing chart elements
       svg.selectAll("*").remove();
 
-      const chartWidth = width - margins.left - margins.right;
-      const chartHeight = height - margins.top - margins.bottom;
+      const chartWidth = dimensions.width - margins.left - margins.right;
+      const chartHeight = dimensions.height - margins.top - margins.bottom;
       let marginLeft = margins.left;
       let marginRight = margins.right;
       let marginTop = margins.top;
@@ -1628,7 +1633,7 @@ const ForecastChart: React.FC = () => {
         // If so, render a message to inform the user
         renderMessage(
           svg,
-          "Not enough data-slices, please extend date range.",
+          "Not enough data, please extend date range.",
           chartWidth,
           chartHeight,
           marginLeft,
@@ -1712,7 +1717,7 @@ const ForecastChart: React.FC = () => {
           marginTop,
           chartWidth,
           chartHeight,
-          height,
+          dimensions.height,
           marginBottom
         );
 
@@ -1727,8 +1732,8 @@ const ForecastChart: React.FC = () => {
       }
     }
   }, [
-    width,
-    height,
+    dimensions,
+    isResizing,
     margins,
     groundTruthData,
     predictionsData,
@@ -1751,10 +1756,13 @@ const ForecastChart: React.FC = () => {
         ref={svgRef}
         width={"100%"}
         height={"100%"}
+        className='w-full h-full'
         preserveAspectRatio='xMidYMid meet'
+        viewBox={`0 0 ${dimensions.width || 100} ${dimensions.height || 100}`}
         style={{
           fontFamily: "var(--font-dm-sans)",
-          visibility: width && height ? "visible" : "hidden",
+          opacity: isResizing ? 0.5 : 1,
+          transition: "opacity 0.1s ease",
         }}></svg>
     </div>
   );

--- a/src/app/interfaces/forecast-interfaces.tsx
+++ b/src/app/interfaces/forecast-interfaces.tsx
@@ -113,7 +113,7 @@ export interface DataPoint {
     referenceDate: Date;
     score: number;
     location: string; // Using US state code
-    horizon: string;
+    horizon: number;
   }
   
   /* Season Aggregation Options, used by Season Overview Page */

--- a/src/app/providers/DataProvider.tsx
+++ b/src/app/providers/DataProvider.tsx
@@ -459,7 +459,10 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
       dispatch(setHistoricalGroundTruthData(historicalData));
       updateLoadingState("historicalGroundTruth", false);
     } catch (error) {
-      console.error("Error fetching historical ground truth data-slices:", error);
+      console.error(
+        "Error fetching historical ground truth data-slices:",
+        error
+      );
       updateLoadingState("historicalGroundTruth", false);
     }
   };
@@ -488,7 +491,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
           referenceDate: Date;
           score: number;
           location: string;
-          horizon: string;
+          horizon: number;
         }[]
       >();
 
@@ -498,7 +501,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
           referenceDate: parseISO(entry.reference_date),
           score: +entry.wis_ratio,
           location: entry.location,
-          horizon: entry.horizon,
+          horizon: +entry.horizon,
         };
 
         const key = modelName;
@@ -511,7 +514,12 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
       // Process MAPE data-slices - Note the capital L in Location
       const mapeByModel = new Map<
         string,
-        { referenceDate: Date; score: number; location: string; horizon: string }[]
+        {
+          referenceDate: Date;
+          score: number;
+          location: string;
+          horizon: number;
+        }[]
       >();
       mapeData.forEach((entry) => {
         const modelName = entry.Model;
@@ -519,7 +527,7 @@ export const DataProvider: React.FC<{ children: React.ReactNode }> = ({
           referenceDate: parseISO(entry.reference_date),
           score: +entry.MAPE * 100,
           location: entry.Location, // Changed from entry.location
-          horizon: entry.horizon,
+          horizon: +entry.horizon,
         };
 
         const key = modelName;


### PR DESCRIPTION
Fixed Single Model page's charts logic, explanation:

Now both charts' x-axis starts from selected season's very first date with valid surveillance date, and end on the very last date which has associated surveillance + prediction data entries matched using referenceDate/date. Note that since the very last day of a season may have prediction associated with X number of horizon ahead (target end date being actually outside this calculated range). This is now handled by checking what `horizon` option user has selected on the page, then extend the calculated range with that number of weeks ahead, to accomodate the last day's forecasts.

Both charts then find correct entries using the x-axis datetime values as the target date in the comparison (previously using referenceDate, hence the bug); for horizon plot, this is straightforward as `target_end_date` is available; for line chart, we instead first narrow the dataset down to those with matching `horizon` with `evaluationsSingleModelViewHorizon`, then get the ones with referenceDate that match `targetDate (from x axis domain again) minus horizon`.